### PR TITLE
upgrade to Django 4.2

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -50,7 +50,11 @@ SECURE_CONTENT_TYPE_NOSNIFF = env.bool("DJANGO_SECURE_CONTENT_TYPE_NOSNIFF", def
 
 # STATIC
 # ------------------------
-STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+STORAGES = {
+    "staticfiles": {
+        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+    },
+}
 # MEDIA
 # ------------------------------------------------------------------------------
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ cerberus==1.3.4  # https://github.com/pyeve/cerberus
 phonenumbers  # https://github.com/daviddrysdale/python-phonenumbers
 # Django
 # ------------------------------------------------------------------------------
-django==4.1.8  # pyup: < 4.2  # https://www.djangoproject.com/
+django==4.2  # https://www.djangoproject.com/
 django-environ==0.10.0  # https://github.com/joke2k/django-environ
 django-model-utils==4.3.1  # https://github.com/jazzband/django-model-utils
 django-allauth==0.54.0  # https://github.com/pennersr/django-allauth
@@ -27,4 +27,4 @@ psycopg-binary==3.1.8
 psycopg==3.1.8
 
 # old db for 4.1.8
-psycopg2-binary==2.9.6
+# psycopg2-binary==2.9.6

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,13 +1,14 @@
 -r base.txt
 
-Werkzeug[watchdog]==2.3.1 # https://github.com/pallets/werkzeug
+Werkzeug[watchdog]==2.3.2 # https://github.com/pallets/werkzeug
 ipdb==0.13.13  # https://github.com/gotcha/ipdb
 pur==7.1.0
+django-upgrade==1.13.0 # https://github.com/adamchainz/django-upgrade
 
 # Testing
 # ------------------------------------------------------------------------------
 mypy==1.2.0  # https://github.com/python/mypy
-django-stubs==1.16.0  # https://github.com/typeddjango/django-stubs
+django-stubs==4.2.0  # https://github.com/typeddjango/django-stubs
 pytest==7.3.1  # https://github.com/pytest-dev/pytest
 pytest-sugar==0.9.7  # https://github.com/Frozenball/pytest-sugar
 
@@ -21,7 +22,7 @@ sphinx-autobuild==2021.3.14 # https://github.com/GaretJax/sphinx-autobuild
 # flake8==6.0.0  # https://github.com/PyCQA/flake8
 # flake8-isort==6.0.0  # https://github.com/gforcada/flake8-isort
 ruff==0.0.263
-coverage==7.2.3  # https://github.com/nedbat/coveragepy
+coverage==7.2.4  # https://github.com/nedbat/coveragepy
 black==23.3.0  # https://github.com/psf/black
 pylint-django==2.5.3  # https://github.com/PyCQA/pylint-django
 pre-commit==3.2.2  # https://github.com/pre-commit/pre-commit

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -3,7 +3,12 @@
 -r base.txt
 
 gunicorn==20.1.0  # https://github.com/benoitc/gunicorn
+
 psycopg2==2.9.6  # https://github.com/psycopg/psycopg2
+# Keeping psycopg2 for now
+#  see https://learndjango.com/tutorials/psycopg3-binary-and-django-42-installation-quick-t
+# psycopg-binary==3.1.8
+# psycopg==3.1.8
 
 # Django
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
@karthicksakkaravarti 
used https://pypi.org/project/django-upgrade/ on settings and models.
Only change is to storage.
django-stubs update requires django 4.2

Also upgraded other packages.
We can upgrade psycopg2, to psycopg3 but need to also update the entry point. I thought we should wait on that.
https://learndjango.com/tutorials/psycopg3-binary-and-django-42-installation-quick-t
